### PR TITLE
Edit metadata.json to support Gnome 43

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "name": "Panel Date Format",
   "description": "Allows to customize the date format on the panel.",
   "url": "https://github.com/KEIII/gnome-shell-panel-date-format",
-  "shell-version": ["40", "41", "42"],
+  "shell-version": ["40", "41", "42", "43"],
   "settings-schema": "org.gnome.shell.extensions.panel-date-format",
   "version": 2
 }


### PR DESCRIPTION
Hi, this adds support for Gnome 43 to the metadata.json file. 
I've tested this a bit on Gnome 43 and it seems to work perfectly fine. 