### PR TITLE
Port extension to GNOME 45.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,26 +1,27 @@
-const { GLib, St, Clutter, Pango } = imports.gi;
-const main = imports.ui.main;
-const ExtensionUtils = imports.misc.extensionUtils;
+import GLib from 'gi://GLib';
+import St from 'gi://St';
+import Clutter from 'gi://Clutter';
+import Pango from 'gi://Pango';
+
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as main from 'resource:///org/gnome/shell/ui/main.js';
 
 let originalClockDisplay;
 let formatClockDisplay;
 let settings;
 let timeoutID = 0;
 
-/**
- * Initialising function which will be invoked at most once directly after your source JS file is loaded.
- */
-function init() {}
+export default class PanelDateFormatExtension extends Extension {
 
 /**
  * Enable, called when extension is enabled or when screen is unlocked.
  */
-function enable() {
+enable() {
   originalClockDisplay = main.panel.statusArea.dateMenu._clockDisplay;
   formatClockDisplay = new St.Label({ style_class: "clock" });
   formatClockDisplay.clutter_text.y_align = Clutter.ActorAlign.CENTER;
   formatClockDisplay.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
-  settings = ExtensionUtils.getSettings();
+  settings = this.getSettings();
 
   // FIXME: Set settings first time to make it visible in dconf Editor
   if (!settings.get_string("format")) {
@@ -37,13 +38,14 @@ function enable() {
 /**
  * Disable, called when extension is disabled or when screen is locked.
  */
-function disable() {
+disable() {
   GLib.Source.remove(timeoutID);
   timeoutID = 0;
   originalClockDisplay.get_parent().remove_child(formatClockDisplay);
   originalClockDisplay.show();
   settings = null;
   formatClockDisplay = null;
+}
 }
 
 /**

--- a/extension.js
+++ b/extension.js
@@ -1,10 +1,9 @@
-import GLib from 'gi://GLib';
-import St from 'gi://St';
-import Clutter from 'gi://Clutter';
-import Pango from 'gi://Pango';
-
-import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
-import * as main from 'resource:///org/gnome/shell/ui/main.js';
+import GLib from "gi://GLib";
+import St from "gi://St";
+import Clutter from "gi://Clutter";
+import Pango from "gi://Pango";
+import { Extension } from "resource:///org/gnome/shell/extensions/extension.js";
+import * as main from "resource:///org/gnome/shell/ui/main.js";
 
 let originalClockDisplay;
 let formatClockDisplay;
@@ -12,10 +11,9 @@ let settings;
 let timeoutID = 0;
 
 export default class PanelDateFormatExtension extends Extension {
-
   /**
-  * Enable, called when extension is enabled or when screen is unlocked.
-  */
+   * Enable, called when extension is enabled or when screen is unlocked.
+   */
   enable() {
     originalClockDisplay = main.panel.statusArea.dateMenu._clockDisplay;
     formatClockDisplay = new St.Label({ style_class: "clock" });
@@ -36,8 +34,8 @@ export default class PanelDateFormatExtension extends Extension {
   }
 
   /**
-  * Disable, called when extension is disabled or when screen is locked.
-  */
+   * Disable, called when extension is disabled or when screen is locked.
+   */
   disable() {
     GLib.Source.remove(timeoutID);
     timeoutID = 0;

--- a/extension.js
+++ b/extension.js
@@ -13,39 +13,39 @@ let timeoutID = 0;
 
 export default class PanelDateFormatExtension extends Extension {
 
-/**
- * Enable, called when extension is enabled or when screen is unlocked.
- */
-enable() {
-  originalClockDisplay = main.panel.statusArea.dateMenu._clockDisplay;
-  formatClockDisplay = new St.Label({ style_class: "clock" });
-  formatClockDisplay.clutter_text.y_align = Clutter.ActorAlign.CENTER;
-  formatClockDisplay.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
-  settings = this.getSettings();
+  /**
+  * Enable, called when extension is enabled or when screen is unlocked.
+  */
+  enable() {
+    originalClockDisplay = main.panel.statusArea.dateMenu._clockDisplay;
+    formatClockDisplay = new St.Label({ style_class: "clock" });
+    formatClockDisplay.clutter_text.y_align = Clutter.ActorAlign.CENTER;
+    formatClockDisplay.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
+    settings = this.getSettings();
 
-  // FIXME: Set settings first time to make it visible in dconf Editor
-  if (!settings.get_string("format")) {
-    settings.set_string("format", "%Y.%m.%d %H:%M");
+    // FIXME: Set settings first time to make it visible in dconf Editor
+    if (!settings.get_string("format")) {
+      settings.set_string("format", "%Y.%m.%d %H:%M");
+    }
+
+    originalClockDisplay.hide();
+    originalClockDisplay
+      .get_parent()
+      .insert_child_below(formatClockDisplay, originalClockDisplay);
+    timeoutID = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1000, tick);
   }
 
-  originalClockDisplay.hide();
-  originalClockDisplay
-    .get_parent()
-    .insert_child_below(formatClockDisplay, originalClockDisplay);
-  timeoutID = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1000, tick);
-}
-
-/**
- * Disable, called when extension is disabled or when screen is locked.
- */
-disable() {
-  GLib.Source.remove(timeoutID);
-  timeoutID = 0;
-  originalClockDisplay.get_parent().remove_child(formatClockDisplay);
-  originalClockDisplay.show();
-  settings = null;
-  formatClockDisplay = null;
-}
+  /**
+  * Disable, called when extension is disabled or when screen is locked.
+  */
+  disable() {
+    GLib.Source.remove(timeoutID);
+    timeoutID = 0;
+    originalClockDisplay.get_parent().remove_child(formatClockDisplay);
+    originalClockDisplay.show();
+    settings = null;
+    formatClockDisplay = null;
+  }
 }
 
 /**

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "name": "Panel Date Format",
   "description": "Allows to customize the date format on the panel.",
   "url": "https://github.com/KEIII/gnome-shell-panel-date-format",
-  "shell-version": ["40", "41", "42", "43", "44", "45"],
+  "shell-version": ["45"],
   "settings-schema": "org.gnome.shell.extensions.panel-date-format",
   "version": 3
 }

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "name": "Panel Date Format",
   "description": "Allows to customize the date format on the panel.",
   "url": "https://github.com/KEIII/gnome-shell-panel-date-format",
-  "shell-version": ["40", "41", "42", "43", "44"],
+  "shell-version": ["40", "41", "42", "43", "44", "45"],
   "settings-schema": "org.gnome.shell.extensions.panel-date-format",
-  "version": 2
+  "version": 3
 }


### PR DESCRIPTION
GNOME Version 45 requires changes from extension developers: https://gjs.guide/extensions/upgrading/gnome-shell-45.html

In particular, we update this extension to use ES modules and the Extension base class.

The first patch keeps indentation incorrect on purpose, to focus on the actual changes required to port the extension. The second patch fixes that.

Please, take into account that I don't know if this updated code works in versions prior to 45, because I've been unable to test that. Maybe the list of "shell-version" has to be trimmed to 45 only.

Thanks for your extension, it's very useful to me and it was the first thing I missed when I upgraded my distro :laughing: 