### PR TITLE
Change every panel (Dash2Panel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Allows to customize the date format on the panel.
 
+If Dash2Panel is being used, every panel is updated.
+
 ![screenshot](./screenshot.png?raw=true)
 
 ## Changing format

--- a/schemas/org.gnome.shell.extensions.panel-date-format.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.panel-date-format.gschema.xml
@@ -1,7 +1,7 @@
 <schemalist>
   <schema id="org.gnome.shell.extensions.panel-date-format" path="/org/gnome/shell/extensions/panel-date-format/">
     <key name="format" type="s">
-      <default>""</default>
+      <default>"%Y.%m.%d %H:%M"</default>
       <summary>Format</summary>
       <description>Format for the clock. Syntax https://developer.gnome.org/glib/stable/glib-GDateTime.html#g-date-time-format</description>
     </key>


### PR DESCRIPTION
I used a forked version of Datetime Format (https://github.com/a1291762/datetime-format) but after upgrading to Ubuntu 24.04, the underlying code was too old. I found this extension that works, and even better, the same logic to support Dash2Panel works here.

This fixes the clock on all panels, not just the primary one.
